### PR TITLE
Fix building, and use Lua 5.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ocvm**
 system/**
 /log
 stack.log
+tmp/**

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ DEPS := $(OBJS:.o=.d)
 
 CPPFLAGS ?= $(INC_FLAGS) -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed
 
-$(TARGET_EXEC): $(OBJS) system/.keep
+$(TARGET_EXEC): $(OBJS) system
 	$(CXX) $(OBJS) -o $@ $(LDFLAGS)
 	@echo done
 
@@ -60,11 +60,14 @@ $(BUILD_DIR)/%.cpp.o: %.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
-system/.keep:
+system:
 	@echo Downloading OpenComputers system files
-	mkdir -p system
-	touch system/.keep
-	command -v svn && svn checkout https://github.com/MightyPirates/OpenComputers/trunk/src/main/resources/assets/opencomputers/loot system/loot || echo "\n\e[36;1mwarning: svn not found. The build will continue, you can manually prepare \`.system/\`\e[m\n"
+
+	git clone -n --depth=1 --filter=tree:0 https://github.com/MightyPirates/OpenComputers/ system/
+	cd system; git sparse-checkout set --no-cone /src/main/resources/assets/opencomputers/loot/; git checkout
+	mv system/src/main/resources/assets/opencomputers/loot/ system/
+	rm -r system/src/
+
 	wget https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/lua/machine.lua -O system/machine.lua
 	wget https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/lua/bios.lua -O system/bios.lua
 	wget https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/font.hex -O system/font.hex
@@ -72,4 +75,4 @@ system/.keep:
 .PHONY: clean
 
 clean:
-	$(RM) -r $(BUILD_DIR) $(TARGET_EXEC) $(TARGET_EXEC)-profiled
+	$(RM) -r $(BUILD_DIR) $(TARGET_EXEC) $(TARGET_EXEC)-profiled system/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifeq ($(lua),)
-	lua=5.2
+	lua=5.4
 endif
 
 TARGET_EXEC ?= ocvm
@@ -11,8 +11,8 @@ ifneq ($(luapath),)
 	LDFLAGS?=${luapath}/liblua.a
 	INC_FLAGS+=-I${luapath}
 else
-	LDFLAGS?=$(shell pkg-config lua$(lua) --libs 2>/dev/null || pkg-config lua5.3 --libs 2>/dev/null || echo -llua5.2)
-	INC_FLAGS+=$(shell pkg-config lua$(lua) --cflags 2>/dev/null || pkg-config lua5.3 --cflags 2>/dev/null || echo -I/usr/include/lua5.2)
+	LDFLAGS?=$(shell pkg-config lua$(lua) --libs 2>/dev/null || pkg-config lua5.4 --libs 2>/dev/null || pkg-config lua5.3 --libs 2>/dev/null || pkg-config lua5.2 --libs 2>/dev/null)
+	INC_FLAGS+=$(shell pkg-config lua$(lua) --cflags 2>/dev/null || pkg-config lua5.4 --cflags 2>/dev/null || pkg-config lua5.3 --cflags 2>/dev/null || pkg-config lua5.2 --cflags 2>/dev/null)
 endif
 
 ifneq ($(prof),)

--- a/drivers/fs_utils.h
+++ b/drivers/fs_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Github dropped SVN support Jan 8 this year, so OCVM no longer properly builds -- I fixed this.
Also, it now prefers Lua versions in this order:
  - `lua=5.x` variable
  - Lua 5.4
  - Lua 5.3
  - Lua 5.2

Plus, it now no longer fails to compile with modern compilers.
(And I added `tmp/` to the gitignore, too.)